### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/context-sources/discourse.csv
+++ b/context-sources/discourse.csv
@@ -16825,7 +16825,7 @@ jobs:
     name: runner / sqlfluff (github-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # only run when a comment requests linting
       - uses: khan/pull-request-comment-trigger@master
         id: check

--- a/context-sources/docs/guides/orchestration/custom-cicd-pipelines/2-lint-on-push.md
+++ b/context-sources/docs/guides/orchestration/custom-cicd-pipelines/2-lint-on-push.md
@@ -59,7 +59,7 @@ jobs:
   
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
       - name: Install SQLFluff

--- a/context-sources/docs/guides/orchestration/custom-cicd-pipelines/3-dbt-cloud-job-on-merge.md
+++ b/context-sources/docs/guides/orchestration/custom-cicd-pipelines/3-dbt-cloud-job-on-merge.md
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
       - name: Run dbt Cloud job

--- a/test-docs/discourse.csv
+++ b/test-docs/discourse.csv
@@ -16825,7 +16825,7 @@ jobs:
     name: runner / sqlfluff (github-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # only run when a comment requests linting
       - uses: khan/pull-request-comment-trigger@master
         id: check


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144