### PR TITLE
Upgrade Jinja2 dependency version specification to address CVE-2024-22195

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ hyperframe==6.0.1
 idna==3.4
 importlib-metadata==6.1.0
 iniconfig==2.0.0
-Jinja2==3.1.2
+Jinja2==3.1.3
 joblib==1.2.0
 langchain==0.0.132
 log-symbols==0.0.14


### PR DESCRIPTION
CVE-2024-22195 identified an issue in Jinja2 versions <= 3.1.2. As such we've gone and changed oure dependency requirement specification to be 3.1.3